### PR TITLE
Fix temporary file cleanup in backups

### DIFF
--- a/utils/backupRunner.js
+++ b/utils/backupRunner.js
@@ -34,8 +34,13 @@ export async function runBackupNow(sourcePath) {
   try {
     await zipDirectory(sourcePath, tempZipPath);
     await uploadToMinio(tempZipPath, `backups/${zipName}`);
-    await fs.remove(tempZipPath);
   } catch (err) {
-    console.error("❌ Erorr at backup:", err.message);
+    console.error("❌ Error at backup:", err.message);
+  } finally {
+    try {
+      await fs.remove(tempZipPath);
+    } catch (removeErr) {
+      console.error("❌ Failed to clean up temp file:", removeErr.message);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- ensure temporary ZIP files are removed even when upload fails
- correct typo in backup error message

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687b679d77e083208124f4264a20e25b